### PR TITLE
Add login-prefix config option for created logins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,94 @@
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+#
+# While our "example" application has the platform-specific code,
+# for simplicity we are compiling and testing everything on the Ubuntu environment only.
+# For multi-OS testing see the `cross.yml` workflow.
+
+on: [push, pull_request]
+
+name: Tests
+
+jobs:
+  check:
+    name: Check ${{ matrix.db_feature }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable]
+        db_feature: [db-sled, db-redis, db-mongo]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --features=secure-auth,${{ matrix.db_feature }},crates-io-mirroring
+
+  test:
+    name: Test ${{ matrix.db_feature }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable]
+        db_feature: [db-sled, db-redis, db-mongo]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=secure-auth,${{ matrix.db_feature }},crates-io-mirroring
+
+  lints:
+    name: Lints (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        continue-on-error: true # Set until the lints are fixed separately
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,9 @@ impl CrateFilesConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct DbConfig {
+    #[serde(default = "DbConfig::login_prefix_default")]
+    pub login_prefix: String,
+
     #[cfg(feature = "db-sled")]
     #[serde(default = "DbConfig::db_dir_path_default")]
     pub db_dir_path: PathBuf,
@@ -92,6 +95,7 @@ pub struct DbConfig {
 impl Default for DbConfig {
     fn default() -> DbConfig {
         DbConfig {
+            login_prefix: DbConfig::login_prefix_default(),
             #[cfg(feature = "db-sled")]
             db_dir_path: DbConfig::db_dir_path_default(),
             #[cfg(feature = "db-redis")]
@@ -103,6 +107,10 @@ impl Default for DbConfig {
 }
 
 impl DbConfig {
+    fn login_prefix_default() -> String {
+        "ktra-secure-auth:".to_owned()
+    }
+
     #[cfg(feature = "db-sled")]
     fn db_dir_path_default() -> PathBuf {
         PathBuf::from("db")

--- a/src/db_manager/traits.rs
+++ b/src/db_manager/traits.rs
@@ -7,6 +7,7 @@ use semver::Version;
 #[async_trait]
 pub trait DbManager: Send + Sync + Sized {
     async fn new(confg: &DbConfig) -> Result<Self, Error>;
+    async fn get_login_prefix(&self) -> Result<&str, Error>;
 
     async fn can_edit_owners(&self, user_id: u32, name: &str) -> Result<bool, Error>;
     async fn owners(&self, name: &str) -> Result<Vec<User>, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,7 @@ fn matches() -> ArgMatches<'static> {
         (@arg DL_DIR_PATH: --("dl-dir-path") +takes_value "Sets the crate files directory")
         (@arg CACHE_DIR_PATH: --("cache-dir-path") +takes_value "Sets the crates.io cache files directory (needs `crates-io-mirroring` feature)")
         (@arg DL_PATH: --("dl-path") +takes_value ... "Sets a crate files download path")
+        (@arg LOGIN_PREFIX: --("login-prefix") +takes_value "Sets the prefix to registered users on the registry.")
         (@arg DB_DIR_PATH: --("db-dir-path") +takes_value "Sets a database directory (needs `db-sled` feature)")
         (@arg REDIS_URL: --("redis-url") + takes_value "Sets a Redis URL (needs `db-redis` feature)")
         (@arg MONGODB_URL: --("mongodb-url") + takes_value "Sets a MongoDB URL (needs `db-mongo` feature)")
@@ -218,6 +219,10 @@ async fn main() -> anyhow::Result<()> {
         .map(|vs| vs.map(ToOwned::to_owned).collect())
     {
         config.crate_files_config.dl_path = dl_path;
+    }
+
+    if let Some(login_prefix) = matches.value_of("LOGIN_PREFIX") {
+        config.db_config.login_prefix = login_prefix.into();
     }
 
     #[cfg(feature = "db-sled")]

--- a/src/post.rs
+++ b/src/post.rs
@@ -41,7 +41,7 @@ async fn handle_new_user(
         .map_ok(|user_id| user_id.map(|u| u + 1).unwrap_or(0))
         .map_err(warp::reject::custom)
         .await?;
-    let login_id = format!("ktra-secure-auth:{}", name);
+    let login_id = format!("{}{}", db_manager.get_login_prefix().await?, name);
     let user = User::new(user_id, login_id, Some(name));
 
     db_manager


### PR DESCRIPTION
Hello,

First, thanks for ktra, it looks like it covers my needs to get a quickly setup for a private registry !

Since there may be a few things that I wanted to tweak (possibly looking into OAuth if I get the courage), I tried to force myself to look into the code by implementing a small feature: I noticed that there is a prefix before the username for all DB related operations, and it was hard coded. I thought it'd be great if it were possible to customize the user_login prefix as well to make ktra feel more "personal". I had to type `cargo owners --registry ktra --add ktra-secure-auth:gagbo` to add an owner, so I thought changing the prefix would be nice as it ends up in the API the users have to use.

The added config option goes under the `db_config` section, and defaults to the previously hardcoded option `ktra-secure-auth:` if absent: so the change is backwards compatible.

Feel free to discard it if you think it's unnecessary, I didn't really create an issue or discussed this point before coming with a patch.

Hopefully I can try to help a little with #28. We're all busy but if we can each give a little time it would probably work out :crossed_fingers: 

Regards,
Gerry