### PR TITLE
Add support for openid for authentication

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,3 +61,33 @@ jobs:
         file: ./docker/ktra.Dockerfile
         tags: ghcr.io/${{ github.repository_owner }}/ktra:${{ env.TAG }}
         push: true
+
+    - name: "`db-redis + openid` build and push"
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./docker/ktra_openid.Dockerfile
+        tags: ghcr.io/${{ github.repository_owner }}/ktra:db-redis-openid-${{ env.TAG }}
+        no-cache: true
+        build-args: |
+          DB=db-redis
+        push: true
+
+    - name: "`db-mongo + openid` build and push"
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./docker/ktra_openid.Dockerfile
+        tags: ghcr.io/${{ github.repository_owner }}/ktra:db-mongo-openid-${{ env.TAG }}
+        no-cache: true
+        build-args: |
+          DB=db-mongo
+        push: true
+
+    - name: "`db-sled + openid` build and push"
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./docker/ktra_openid.Dockerfile
+        tags: ghcr.io/${{ github.repository_owner }}/ktra:openid-${{ env.TAG }}
+        push: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,33 @@ jobs:
           command: check
           args: --no-default-features --features=secure-auth,${{ matrix.db_feature }},crates-io-mirroring
 
+  check_openid:
+    name: Check ${{ matrix.db_feature }} with OpenId (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable]
+        db_feature: [db-sled, db-redis, db-mongo]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --features=secure-auth,${{ matrix.db_feature }},crates-io-mirroring,openid
+
+
   test:
     name: Test ${{ matrix.db_feature }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = ["secure-auth", "db-sled", "crates-io-mirroring"]
 secure-auth = ["rand", "rust-argon2"]
 crates-io-mirroring = ["reqwest", "tokio-util"]
 mirroring-dummy = []
+openid = ["openidconnect", "reqwest"]
 db-sled = ["sled"]
 db-redis = ["redis"]
 db-mongo = ["mongodb", "bson"]
@@ -41,7 +42,7 @@ toml = "0.5"
 clap = "2.33"
 async-trait = "0.1"
 
-reqwest = { version = "0.11", features = ["gzip", "brotli"], optional = true }
+reqwest = { version = "0.11", features = ["gzip", "brotli", "json"], optional = true }
 tokio-util = { version = "0.6", features = ["io"], optional = true }
 
 rand = { version = "0.8", optional = true }
@@ -52,3 +53,4 @@ redis = { version = "0.19", features = ["tokio-comp"], optional = true }
 mongodb = { version = "1.1", optional = true }
 bson = { version = "1.1", features = ["u2i"], optional = true }
 
+openidconnect = { version = "2.1.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -25,20 +25,38 @@ Any commit on `develop` branch builds images listed below:
 
 - `latest`
     - `db-sled` featured image.
+- `openid-latest`
+    - `db-sled` featured image.
+    - `openid` support for authentication
 - `db-redis-latest`
     - `db-redis` featured image.
+- `db-redis-openid-latest`
+    - `db-redis` featured image.
+    - `openid` support for authentication
 - `db-mongo-latest`
     - `db-mongo` featured image.
+- `db-mongo-openid-latest`
+    - `db-mongo` featured image.
+    - `openid` support for authentication
 
 
 Similarly, images below are built automatically when tags are pushed:
 
 - `{VERSION}` *(e.g. `0.4.3`)*
     - `db-sled` featured image.
+- `openid-{VERSION}`
+    - `db-sled` featured image.
+    - `openid` support for authentication
 - `db-redis-{VERSION}`
     - `db-redis` featured image.
+- `db-redis-openid-{VERSION}`
+    - `db-redis` featured image.
+    - `openid` support for authentication
 - `db-mongo-{VERSION}`
     - `db-mongo` featured image.
+- `db-mongo-openid-{VERSION}`
+    - `db-mongo` featured image.
+    - `openid` support for authentication
 
 Please see [*"Installation: Docker"* page in The Ktra Book](https://book.ktra.dev/installation/docker.html) for more details.
 ## Features
@@ -67,8 +85,11 @@ Please see [*"Installation: Docker"* page in The Ktra Book](https://book.ktra.de
 - [x] [crates.io mirroring](https://github.com/moriturus/ktra/issues/8).
     - via `crates-io-mirroring` feature turned on by default. 
 
+#### From 0.7.0
+- [x] OpenID support for auto-discoverable identity providers (e.g. Gitlab, _not_ Github)
+
 ### Planned
-- [ ] OAuth and/or OpenID support.
+- [ ] OAuth and/or OpenID support for all identity providers
 - [ ] RDBMS such as [PostgresQL](https://www.postgresql.org/), [MySQL](https://www.mysql.com/) and [MariaDB](https://mariadb.org/) support.
 - [ ] The crates browser like [crates.io](https://crates.io/)
 

--- a/docker/ktra_openid.Dockerfile
+++ b/docker/ktra_openid.Dockerfile
@@ -15,7 +15,7 @@ COPY --chown=rust:rust ./src /build/src
 COPY --chown=rust:rust ./Cargo.toml /build/
 WORKDIR /build
 
-RUN cargo build --release --no-default-features --features=secure-auth,${DB},${MIRRORING}
+RUN cargo build --release --no-default-features --features=secure-auth,openid,${DB},${MIRRORING}
 
 FROM debian:bullseye-slim
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,18 @@ impl ServerConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct OpenIdConfig {
+    pub(crate) issuer_url: String,
+    pub(crate) redirect_url: String,
+    pub(crate) client_id: String,
+    pub(crate) client_secret: String,
+    #[serde(default)]
+    pub(crate) additional_scopes: Vec<String>,
+    pub(crate) gitlab_authorized_groups: Option<Vec<String>>,
+    pub(crate) gitlab_authorized_users: Option<Vec<String>>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     #[serde(default)]
@@ -168,6 +180,8 @@ pub struct Config {
     pub index_config: IndexConfig,
     #[serde(default)]
     pub server_config: ServerConfig,
+    #[serde(default)]
+    pub openid_config: OpenIdConfig,
 }
 
 impl Default for Config {
@@ -177,6 +191,7 @@ impl Default for Config {
             db_config: Default::default(),
             index_config: Config::index_config_default(),
             server_config: Default::default(),
+            openid_config: Default::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,7 @@ impl ServerConfig {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct OpenIdConfig {
     pub(crate) issuer_url: String,

--- a/src/db_manager/traits.rs
+++ b/src/db_manager/traits.rs
@@ -16,8 +16,11 @@ pub trait DbManager: Send + Sync + Sized {
 
     async fn last_user_id(&self) -> Result<Option<u32>, Error>;
     async fn user_id_for_token(&self, token: &str) -> Result<u32, Error>;
+    async fn token_by_login(&self, login: &str) -> Result<Option<String>, Error>;
+    async fn token_by_username(&self, name: &str) -> Result<Option<String>, Error>;
     async fn set_token(&self, user_id: u32, token: &str) -> Result<(), Error>;
     async fn user_by_username(&self, name: &str) -> Result<User, Error>;
+    async fn user_by_login(&self, login: &str) -> Result<User, Error>;
     async fn add_new_user(&self, user: User, password: &str) -> Result<(), Error>;
     async fn verify_password(&self, user_id: u32, password: &str) -> Result<bool, Error>;
     async fn change_password(
@@ -45,4 +48,19 @@ pub trait DbManager: Send + Sync + Sized {
     async fn unyank(&self, name: &str, version: Version) -> Result<(), Error>;
 
     async fn search(&self, query: &Query) -> Result<Search, Error>;
+
+    /// Store a nonce associated to a CsrfToken. A single entry is allowed per CsrfToken
+    #[cfg(feature = "openid")]
+    async fn store_nonce_by_csrf(
+        &self,
+        state: openidconnect::CsrfToken,
+        nonce: openidconnect::Nonce,
+    ) -> Result<(), Error>;
+
+    /// Find the nonce associated to a CsrfToken, and remove the association in database.
+    #[cfg(feature = "openid")]
+    async fn get_nonce_by_csrf(
+        &self,
+        state: openidconnect::CsrfToken,
+    ) -> Result<openidconnect::Nonce, Error>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,8 @@ pub enum Error {
         any(feature = "db-mongo", feature = "crates-io-mirroring"),
         not(all(feature = "db-sled", feature = "db-redis"))
     ))]
+    #[error("Openid error: {}", _0)]
+    OpenId(String),
     #[error("URL parsing error: {}", _0)]
     UrlParsing(url::ParseError),
     #[error("the given passwords are the same")]
@@ -83,10 +85,14 @@ pub enum Error {
     InvalidCrateName(String),
     #[error("invalid token: {}", _0)]
     InvalidToken(String),
+    #[error("invalid csrf state: {}", _0)]
+    InvalidCsrfToken(String),
     #[error("invalid user id: {}", _0)]
     InvalidUser(u32),
     #[error("invalid username: {}", _0)]
     InvalidUsername(String),
+    #[error("invalid login: {}", _0)]
+    InvalidLogin(String),
     #[error("invalid password")]
     InvalidPassword,
     #[error("one or more invalid login names are detected: {:?}", _0)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,10 +39,7 @@ pub enum Error {
     Git(git2::Error),
     #[error("argon2 error: {}", _0)]
     Argon2(argon2::Error),
-    #[cfg(all(
-        any(feature = "db-mongo", feature = "crates-io-mirroring"),
-        not(all(feature = "db-sled", feature = "db-redis"))
-    ))]
+    #[cfg(any(feature = "openid"))]
     #[error("Openid error: {}", _0)]
     OpenId(String),
     #[error("URL parsing error: {}", _0)]
@@ -85,6 +82,7 @@ pub enum Error {
     InvalidCrateName(String),
     #[error("invalid token: {}", _0)]
     InvalidToken(String),
+    #[cfg(feature = "openid")]
     #[error("invalid csrf state: {}", _0)]
     InvalidCsrfToken(String),
     #[error("invalid user id: {}", _0)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -302,3 +302,23 @@ pub struct ChangePassword {
     pub old_password: String,
     pub new_password: String,
 }
+
+#[cfg(feature = "openid")]
+#[derive(Debug, Clone, Deserialize)]
+pub struct CodeQuery {
+    pub code: String,
+    pub state: Option<String>,
+}
+
+/// The additional claims OpenId providers may send
+///
+/// All fields here are options so that the extra claims are caught when presents
+#[cfg(feature = "openid")]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Claims {
+    pub(crate) sub: Option<String>,
+    pub(crate) sub_legacy: Option<String>,
+    // Gitlab claims return the groups a user is in.
+    // This property is used when gitlab_authorized_groups is set in the configuration
+    pub(crate) groups: Option<Vec<String>>,
+}

--- a/src/openid.rs
+++ b/src/openid.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "openid")]
+
 use crate::config::OpenIdConfig;
 use crate::db_manager::DbManager;
 use crate::error::Error;
@@ -252,14 +253,22 @@ async fn get_openid_client(
     ))
 }
 
-#[tracing::instrument(skip(openid_config, id_token, userinfo))]
+#[tracing::instrument(skip(openid_config, _id_token, userinfo))]
 fn check_user_authorization<GC: openidconnect::GenderClaim>(
     openid_config: Arc<OpenIdConfig>,
-    id_token: &CoreIdTokenClaims,
+    _id_token: &CoreIdTokenClaims,
     userinfo: &UserInfoClaims<Claims, GC>,
 ) -> bool {
-    if openid_config.gitlab_authorized_users.is_none()
-        && openid_config.gitlab_authorized_groups.is_none()
+    if openid_config
+        .gitlab_authorized_users
+        .as_ref()
+        .map(Vec::is_empty)
+        .unwrap_or(true)
+        && openid_config
+            .gitlab_authorized_groups
+            .as_ref()
+            .map(Vec::is_empty)
+            .unwrap_or(true)
     {
         tracing::info!("no openid config authorization restrictions, authorizing.");
         return true;

--- a/src/openid.rs
+++ b/src/openid.rs
@@ -1,0 +1,373 @@
+#![cfg(feature = "openid")]
+use crate::config::OpenIdConfig;
+use crate::db_manager::DbManager;
+use crate::error::Error;
+use crate::models::{Claims, CodeQuery, User};
+use crate::utils::*;
+use futures::TryFutureExt;
+use openidconnect::core::{
+    CoreClient, CoreGenderClaim, CoreIdTokenClaims, CoreIdTokenVerifier, CoreProviderMetadata,
+    CoreResponseType,
+};
+use openidconnect::{
+    AdditionalClaims, AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
+    IssuerUrl, Nonce, OAuth2TokenResponse, RedirectUrl, Scope, UserInfoClaims,
+};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use warp::{Filter, Rejection, Reply};
+
+impl AdditionalClaims for Claims {}
+
+#[tracing::instrument(skip(db_manager, openid_config))]
+pub fn apis(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    authenticate(db_manager.clone(), openid_config.clone())
+        .or(me(db_manager.clone(), openid_config.clone()))
+        .or(handle_replace_token(
+            db_manager.clone(),
+            openid_config.clone(),
+        ))
+        .or(replace_token(db_manager, openid_config))
+}
+
+#[tracing::instrument(skip(db_manager, openid_config))]
+fn authenticate(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::get()
+        .and(with_db_manager(db_manager))
+        .and(with_openid_config(openid_config))
+        .and(warp::path!("ktra" / "api" / "v1" / "openid" / "me"))
+        .and(warp::query::<CodeQuery>())
+        .and_then(validate)
+}
+
+#[tracing::instrument(skip(db_manager, openid_config))]
+fn handle_replace_token(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::get()
+        .and(with_db_manager(db_manager))
+        .and(with_openid_config(openid_config))
+        .and(warp::path!("ktra" / "api" / "v1" / "openid" / "replace"))
+        .and(warp::query::<CodeQuery>())
+        .and_then(validate_and_replace)
+}
+
+#[tracing::instrument(skip(db_manager, openid_config))]
+fn me(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::get()
+        .and(with_db_manager(db_manager))
+        .and(with_openid_config(openid_config))
+        .and(warp::path!("me"))
+        .and_then(initiate_openid)
+}
+
+#[tracing::instrument(skip(db_manager, openid_config))]
+fn replace_token(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::get()
+        .and(with_db_manager(db_manager))
+        .and(with_openid_config(openid_config))
+        .and(warp::path!("replace_token"))
+        .and_then(replace_openid)
+}
+
+#[tracing::instrument(skip(db_manager, openid_config))]
+async fn initiate_openid(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+) -> Result<warp::reply::Response, Rejection> {
+    start_openid_with_redirect(db_manager, openid_config, "ktra/api/v1/openid/me").await
+}
+
+#[tracing::instrument(skip(db_manager, openid_config))]
+async fn replace_openid(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+) -> Result<warp::reply::Response, Rejection> {
+    start_openid_with_redirect(db_manager, openid_config, "ktra/api/v1/openid/replace").await
+}
+
+#[tracing::instrument(skip(db_manager, openid_config))]
+async fn start_openid_with_redirect(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+    redirect_path: &str,
+) -> Result<warp::reply::Response, Rejection> {
+    let db_manager = db_manager.write().await;
+
+    let client = get_openid_client(openid_config.clone(), redirect_path).await?;
+
+    let mut url_builder = client.authorize_url(
+        AuthenticationFlow::<CoreResponseType>::AuthorizationCode,
+        CsrfToken::new_random,
+        Nonce::new_random,
+    );
+    for scope in openid_config.additional_scopes.iter().cloned() {
+        url_builder = url_builder.add_scope(Scope::new(scope));
+    }
+    let (authorize_url, csrf_state, nonce) = url_builder.url();
+
+    // Store the nonce for comparison later in the redirect endpoint
+    db_manager.store_nonce_by_csrf(csrf_state, nonce).await?;
+
+    Ok(warp::redirect::temporary(
+        authorize_url
+            .as_str()
+            .parse::<openidconnect::http::Uri>()
+            .unwrap(),
+    )
+    .into_response())
+}
+
+#[tracing::instrument(skip(db_manager, openid_config, query))]
+async fn validate(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+    query: CodeQuery,
+) -> Result<warp::reply::Response, Rejection> {
+    finish_openid_with_redirect(
+        db_manager,
+        openid_config,
+        query,
+        "ktra/api/v1/openid/me",
+        false,
+    )
+    .await
+}
+
+#[tracing::instrument(skip(db_manager, openid_config, query))]
+async fn validate_and_replace(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+    query: CodeQuery,
+) -> Result<warp::reply::Response, Rejection> {
+    finish_openid_with_redirect(
+        db_manager,
+        openid_config,
+        query,
+        "ktra/api/v1/openid/replace",
+        true,
+    )
+    .await
+}
+
+#[tracing::instrument(skip(db_manager, openid_config, query))]
+async fn finish_openid_with_redirect(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    openid_config: Arc<OpenIdConfig>,
+    query: CodeQuery,
+    redirect_path: &str,
+    revoke_old_token: bool,
+) -> Result<warp::reply::Response, Rejection> {
+    let client = get_openid_client(openid_config.clone(), redirect_path).await?;
+
+    let code = AuthorizationCode::new(query.code);
+    let state = CsrfToken::new(query.state.unwrap());
+    let nonce = db_manager.write().await.get_nonce_by_csrf(state).await?;
+    let token_response = client
+        .exchange_code(code)
+        .request_async(openidconnect::reqwest::async_http_client)
+        .await
+        .map_err(|_| {
+            warp::reject::custom(Error::OpenId(
+                "Failed to contact token endpoint".to_string(),
+            ))
+        })?;
+
+    let id_token_verifier: CoreIdTokenVerifier = client.id_token_verifier();
+    let id_token_claims: &CoreIdTokenClaims = token_response
+        .extra_fields()
+        .id_token()
+        .ok_or_else(|| {
+            warp::reject::custom(Error::OpenId(
+                "Server did not return an ID token".to_string(),
+            ))
+        })?
+        .claims(&id_token_verifier, &nonce)
+        .map_err(|_| {
+            warp::reject::custom(Error::OpenId("Failed to verify ID token".to_string()))
+        })?;
+
+    let userinfo_claims: UserInfoClaims<Claims, CoreGenderClaim> = client
+        .user_info(token_response.access_token().to_owned(), None)
+        .map_err(|_| warp::reject::custom(Error::OpenId("No user info endpoint".to_string())))?
+        .request_async(openidconnect::reqwest::async_http_client)
+        .await
+        .map_err(|_| {
+            warp::reject::custom(Error::OpenId("Failed requesting user info".to_string()))
+        })?;
+
+    if !check_user_authorization(openid_config, id_token_claims, &userinfo_claims) {
+        Err(warp::reject::custom(Error::OpenId(
+            "Unauthorized user for publishing/owning rights".to_string(),
+        )))
+    } else {
+        handle_authorized_user(
+            db_manager,
+            id_token_claims,
+            &userinfo_claims,
+            revoke_old_token,
+        )
+        .await
+    }
+}
+
+#[tracing::instrument(skip(openid_config))]
+async fn get_openid_client(
+    openid_config: Arc<OpenIdConfig>,
+    redirect_path: &str,
+) -> Result<CoreClient, Rejection> {
+    let issuer = IssuerUrl::new(openid_config.issuer_url.clone())
+        .map_err(|_| warp::reject::custom(Error::OpenId("Invalid issuer URL".to_string())))?;
+    let redirect_url = format!("{}/{}", openid_config.redirect_url, redirect_path);
+    let provider_metadata =
+        CoreProviderMetadata::discover_async(issuer, openidconnect::reqwest::async_http_client)
+            .map_err(|_| {
+                warp::reject::custom(Error::OpenId(
+                    "Failed to discover OpenID Provider".to_string(),
+                ))
+            })
+            .await?;
+
+    Ok(CoreClient::from_provider_metadata(
+        provider_metadata,
+        ClientId::new(openid_config.client_id.to_string()),
+        Some(ClientSecret::new(openid_config.client_secret.to_string())),
+    )
+    .set_redirect_uri(
+        RedirectUrl::new(redirect_url)
+            .map_err(|_| warp::reject::custom(Error::OpenId("Invalid redirect URL".to_string())))?,
+    ))
+}
+
+#[tracing::instrument(skip(openid_config, id_token, userinfo))]
+fn check_user_authorization<GC: openidconnect::GenderClaim>(
+    openid_config: Arc<OpenIdConfig>,
+    id_token: &CoreIdTokenClaims,
+    userinfo: &UserInfoClaims<Claims, GC>,
+) -> bool {
+    if openid_config.gitlab_authorized_users.is_none()
+        && openid_config.gitlab_authorized_groups.is_none()
+    {
+        tracing::info!("no openid config authorization restrictions, authorizing.");
+        return true;
+    }
+    if let Some(ref auth_groups) = openid_config.gitlab_authorized_groups {
+        if let Some(ref groups) = userinfo.additional_claims().groups {
+            for group in groups {
+                if auth_groups.contains(group) {
+                    tracing::info!("matched authorized group {}, authorizing.", group);
+                    return true;
+                }
+            }
+        }
+    }
+    if let Some(ref auth_users) = openid_config.gitlab_authorized_users {
+        if auth_users.contains(
+            &userinfo
+                .nickname()
+                .map(|nick| nick.get(None).unwrap().as_str().to_string())
+                .unwrap_or_default(),
+        ) {
+            tracing::info!("matched authorized nickname, authorizing.");
+            return true;
+        }
+    }
+    return false;
+}
+
+#[tracing::instrument(skip(db_manager, userinfo))]
+async fn handle_authorized_user<GC: openidconnect::GenderClaim>(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    id_token: &CoreIdTokenClaims,
+    userinfo: &UserInfoClaims<Claims, GC>,
+    revoke_old_token: bool,
+) -> Result<warp::reply::Response, Rejection> {
+    let issuer = id_token.issuer().url().host_str().ok_or_else(|| {
+        warp::reject::custom(Error::OpenId("Invalid scheme for issuer URL".to_string()))
+    })?;
+    let name = userinfo
+        .nickname()
+        .ok_or_else(|| {
+            warp::reject::custom(Error::OpenId(
+                "No nickname available for registration in Ktra".to_string(),
+            ))
+        })?
+        .get(None)
+        .ok_or_else(|| {
+            warp::reject::custom(Error::OpenId(
+                "No nickname available for default locale registration in Ktra".to_string(),
+            ))
+        })?
+        .as_str();
+
+    let user = get_or_create_user(db_manager.clone(), issuer, name).await?;
+    let existing_token = db_manager.read().await.token_by_login(&user.login).await?;
+
+    if revoke_old_token || existing_token.is_none() {
+        let new_token = random_alphanumeric_string(32)
+            .map_err(warp::reject::custom)
+            .await?;
+        db_manager
+            .write()
+            .await
+            .set_token(user.id, &new_token)
+            .map_err(warp::reject::custom)
+            .await?;
+
+        Ok(warp::reply::json(&serde_json::json!({
+            "username": user.login,
+            "new_token": new_token,
+            "revoked_token": existing_token
+        }))
+        .into_response())
+    } else {
+        Ok(warp::reply::json(&serde_json::json!({
+            "username": user.login,
+            "existing_token": existing_token.expect("existing_token is Some(_) in this branch.")
+        }))
+        .into_response())
+    }
+}
+
+async fn get_or_create_user(
+    db_manager: Arc<RwLock<impl DbManager>>,
+    issuer: &str,
+    name: &str,
+) -> Result<User, Rejection> {
+    let db_manager = db_manager.write().await;
+
+    let login_id = format!("{}:{}", issuer, name);
+
+    if let Ok(user) = db_manager.user_by_login(&login_id).await {
+        return Ok(user);
+    }
+
+    let user_id = db_manager
+        .last_user_id()
+        .map_ok(|user_id| user_id.map(|u| u + 1).unwrap_or(0))
+        .map_err(warp::reject::custom)
+        .await?;
+    let user = User::new(user_id, login_id, Some(name));
+
+    db_manager
+        .add_new_user(
+            user.clone(),
+            "passphrases are unsupported with openid feature",
+        )
+        .map_err(warp::reject::custom)
+        .await?;
+    Ok(user)
+}

--- a/src/post.rs
+++ b/src/post.rs
@@ -1,3 +1,6 @@
+#![cfg(not(feature = "openid"))]
+// The "POST" endpoints in this module are all concerning user and password management,
+// which are irrelevant with openid enabled
 use crate::db_manager::DbManager;
 use crate::error::Error;
 use crate::models::User;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::config::OpenIdConfig;
 use crate::db_manager::DbManager;
 use crate::error::Error;
 use crate::index_manager::IndexManager;
@@ -104,6 +105,13 @@ pub fn with_index_manager(
     index_manager: Arc<IndexManager>,
 ) -> impl Filter<Extract = (Arc<IndexManager>,), Error = Infallible> + Clone {
     warp::any().map(move || index_manager.clone())
+}
+
+#[tracing::instrument(skip(openid_config))]
+pub fn with_openid_config(
+    openid_config: Arc<OpenIdConfig>,
+) -> impl Filter<Extract = (Arc<OpenIdConfig>,), Error = Infallible> + Clone {
+    warp::any().map(move || openid_config.clone())
 }
 
 #[tracing::instrument]


### PR DESCRIPTION
# TODO

- [x] Update the readme with the new image tags.
- [x] Make a PR to https://github.com/moriturus/ktra-book to add the oid guide, and explicitely state somewhere that a user can currently only have one active and valid token at any given time, just like the other implementations.
- [x] Add another oid endpoint to only fetch the current token without changing it. 

# PR Summary

The implementation is being dogfed with gitlab as the OpenID issuer.

In order to work, the issuer needs to:
- be discoverable (with `GET /.well-known/openid-configuration`)
- have a `userinfo_endpoint` in the openid configuration

Authentication is done through white-listing. If there are no whitelist
fields, then anyone can create an account, therefore can publish and own
crates in the registry.

When ktra is built with openid, all the user management endpoints are
disabled to avoid tampering through unauthenticated `POST` calls.

Also, there is no point storing a password, but as the password
interface is strongly coupled with the DbManager trait, for the time
being a dummy password is inserted for users. This is deemed not
dangerous as all authenticated routes aren't compiled when the "openid"
feature is present

A `user_by_login` function has been added to the DbManager trait because
the login is now dynamically computed from the OpenId issuer.

---

## Other notable changes

- A test workflow, mostly to test all db implementations with/without openid (it should at least compile)
- Bumping the docker base image to Rust 1.56, latest stable version
- Push extra docker images with openid enabled

## Notes

I tried to keep the code somewhat generic in order to allow other issuers to plug in easily, but the changes are still geared towards my company's usecase (being "we want to use gitlab openid for user authentication"). This shows mostly in 4 different points :
- requiring a discoverable config
- requiring a userinfo_endpoint
- adding extra fields in `models::Claims` which (optionally) match the extra claims from gitlab OpenId I want to use
- adding extra fields in `config::OpenIdConfig` which (optionally) describe the authorized gitlab entities on the registry

As is, I think it's ready for this usecase, so I'm pushing the PR here if anyone wants to review it/start using it, modifications are welcome. (I know I can build a docker image from it for my use case so that's good enough for me even if the PR doesn't make it)

## Example

With this config
```toml
[index_config]
remote_url = "[redacted]"
https_username = "gagbo"
https_password = "[redacted]"
branch = "master"

[openid_config]
issuer_url = "https://gitlab.com"
redirect_url = "http://registry.szl"
client_id = "717dc...."
client_secret = "[redacted]"
additional_scopes = ["openid", "profile", "email"]
gitlab_authorized_groups = [ "firm/groups/crate_owners" ]
gitlab_authorized_users = [ "gagbo" ]

[server_config]
port = 80

```

The client_id/client_secret pair is coming from Gitlab where I added an application to my profile for test purpose, with the scopes `openid`, `profile`, and `email` 

![ktra-test-oauth-app](https://user-images.githubusercontent.com/10496163/142413427-2d97c5e9-61e3-41fa-8ed2-ec5404e4ba27.png)

Upon going to `registry-url/me` I arrive at the sign on for Gitlab where I authorize the app, and then after redirection firefox is showing me my token :

![post_gitlab_signon](https://user-images.githubusercontent.com/10496163/142412098-5f454992-1279-4af1-9836-be63d9bd105e.png)

(The `username` has since been modified to `gitlab.com:gagbo` instead)

and I can use it locally :

![cargo_login_publish](https://user-images.githubusercontent.com/10496163/142412216-4469cc87-5f5b-4667-99c2-f3428e83f6e0.png)

