### PR TITLE
Fix race condition when writing/committing index

### DIFF
--- a/src/index_manager.rs
+++ b/src/index_manager.rs
@@ -75,7 +75,7 @@ impl IndexManager {
         file.set_len(0).await?;
         file.seek(SeekFrom::Start(0)).await?;
         file.write_all(content.as_bytes()).await?;
-        file.flush().await?;
+        file.sync_all().await?;
 
         let message = format!("Updating crate `{}#{}`", package.name, package.vers);
         let repository = self.repository.lock().await;
@@ -144,7 +144,7 @@ impl IndexManager {
         file.set_len(0).await?;
         file.seek(SeekFrom::Start(0)).await?;
         file.write_all(content.as_bytes()).await?;
-        file.flush().await?;
+        file.sync_all().await?;
 
         let message = if yanked {
             format!("Yanking crate `{}#{}`", name, version)


### PR DESCRIPTION
Piggybacking on #21, use `sync_all` instead of `flush`.

`flush` commits the changes to the filesystem, but makes no guarantees as to when those changes will land in the fs. Instead, use `sync_all` to force the program to wait for the writes to be fully propagated to the file system before committing to the index repo. Otherwise it would sometimes happen that an empty file would be committed and pushed to the index before the additions were written to disk.

Reference: https://stackoverflow.com/questions/69819990/whats-the-difference-between-flush-and-sync-all