### PR TITLE
Fix dockerfile and reduce size by removing apt-get artifacts

### DIFF
--- a/docker/ktra.Dockerfile
+++ b/docker/ktra.Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1.58-slim-bullseye as builder
+FROM rust:1.59-slim-bullseye as builder
 
 ARG DB="db-sled"
 ARG MIRRORING="crates-io-mirroring"
 
 RUN apt-get update &&\
-    apt-get upgrade &&\
+    apt-get upgrade -y &&\
     apt-get install -y openssl pkg-config libssl-dev
 
 RUN useradd -m rust
@@ -24,8 +24,10 @@ LABEL org.opencontainers.image.documentation https://book.ktra.dev
 LABEL org.opencontainers.image.licenses "(Apache-2.0 OR MIT)"
 
 RUN apt-get update &&\
-    apt-get upgrade &&\
-    apt-get install -y libssl1.1 ca-certificates
+    apt-get upgrade -y &&\
+    apt-get install -y libssl1.1 ca-certificates &&\
+    apt-get autoremove -y &&\
+    apt-get clean -y
 
 COPY LICENSE-APACHE ./
 COPY LICENSE-MIT ./


### PR DESCRIPTION
Quick fix CI and allow `apt-get update` to complete succesfully. Also, reduce the final size of dockerfile by removing apt artifacts.