### PR TITLE
Add support for sparse index by serving registry over HTTP as static file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ mirroring-dummy = []
 db-sled = ["sled"]
 db-redis = ["redis"]
 db-mongo = ["mongodb", "bson"]
+sparse-index = []
 
 [dependencies]
 tokio = { version = "1.1", features = ["macros", "rt-multi-thread", "fs", "io-util"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,18 @@ impl ServerConfig {
     }
 }
 
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct SparseIndexConfig {
+    pub(crate) path: String,
+}
+impl Default for SparseIndexConfig {
+    fn default() -> Self {
+        Self {
+            path: String::from("api/v1/crates"),
+        }
+    }
+}
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     #[serde(default)]
@@ -168,6 +180,8 @@ pub struct Config {
     pub index_config: IndexConfig,
     #[serde(default)]
     pub server_config: ServerConfig,
+    #[serde(default)]
+    pub sparse_index_config: SparseIndexConfig,
 }
 
 impl Default for Config {
@@ -177,6 +191,7 @@ impl Default for Config {
             db_config: Default::default(),
             index_config: Config::index_config_default(),
             server_config: Default::default(),
+            sparse_index_config: Default::default(),
         }
     }
 }

--- a/src/get.rs
+++ b/src/get.rs
@@ -53,7 +53,7 @@ pub fn apis(
 }
 
 #[tracing::instrument(skip(path))]
-fn into_boxed_filters(path: Vec<String>) -> BoxedFilter<()> {
+pub(crate) fn into_boxed_filters(path: Vec<String>) -> BoxedFilter<()> {
     let (h, t) = path.split_at(1);
     t.iter().fold(warp::path(h[0].clone()).boxed(), |accm, s| {
         accm.and(warp::path(s.clone())).boxed()

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "sparse-index")]
+
+use std::convert::Infallible;
+use std::path::PathBuf;
+
+use warp::path::Tail;
+use warp::{reject, Filter, Rejection, Reply};
+
+use crate::config::SparseIndexConfig;
+use crate::get::into_boxed_filters;
+
+#[tracing::instrument(skip(sparse_index_config, local_index_path))]
+pub fn apis(
+    sparse_index_config: SparseIndexConfig,
+    local_index_path: PathBuf,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    into_boxed_filters(
+        sparse_index_config
+            .path
+            .split('/')
+            .map(ToString::to_string)
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>(),
+    )
+    .and(warp::path::tail())
+    .and(with_local_index_path(local_index_path))
+    .and_then(read_crate_index)
+}
+
+#[tracing::instrument(skip(path))]
+fn with_local_index_path(
+    path: PathBuf,
+) -> impl Filter<Extract = (PathBuf,), Error = Infallible> + Clone {
+    warp::any().map(move || path.clone())
+}
+
+#[tracing::instrument(skip(tail, local_index_path))]
+async fn read_crate_index(tail: Tail, local_index_path: PathBuf) -> Result<String, Rejection> {
+    if tail.as_str().starts_with(".") {
+        Err(reject::not_found())
+    } else {
+        std::fs::read_to_string(local_index_path.join(tail.as_str()))
+            .map_err(|_| reject::not_found())
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use warp::{Filter, Rejection, Reply};
 
+#[allow(dead_code)]
 #[inline]
 pub fn always_true<T>(_: T) -> bool {
     true


### PR DESCRIPTION
Serving registry over HTTP as static file is a feature described in [rust-lang/rfcs#2789](https://github.com/rust-lang/rfcs/pull/2789), and the implementation [rust-lang/cargo#10470](https://github.com/rust-lang/cargo/pull/10470) is already merged in cargo currently as unstable feature `http-registry`.

This PR add support for http-registry by serving index files over HTTP, and ignored hidden file to avoid leaking `.git` folder.

1. add `sparse_index_config` in config to control HTTP registry path
    ```toml
    [sparse_index_config]
    path = "api/v1/crates"
    ```
2. add feature gate `sparse-index` to enable http registry endpoint