### PR TITLE
chore(CI): allow push to crates.io for version tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,10 @@
 # for simplicity we are compiling and testing everything on the Ubuntu environment only.
 # For multi-OS testing see the `cross.yml` workflow.
 
-on: [push, pull_request]
+on: 
+  workflow_dispatch
 
-name: Tests
+name: Publish
 
 jobs:
   check:
@@ -119,3 +120,22 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  publish:
+    name: Publish Package
+    needs: [check, lints, test]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: login
+        env:
+          SUPER_SECRET: ${{ secrets.CARGO_TOKEN }}
+        run: cargo login "$SUPER_SECRET"
+        shell: bash
+
+      - name: publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,3 +119,22 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  publish:
+    name: Publish Package
+    needs: [check, lints, test]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: login
+        env:
+          SUPER_SECRET: ${{ secrets.CARGO_TOKEN }}
+        run: cargo login "$SUPER_SECRET"
+        shell: bash
+
+      - name: publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish


### PR DESCRIPTION
Current workflow require manual action by @moriturus when publishing new version to crates.io.

This PR enable github action to push new version to crates.io for version tag (e.x. `v0.6.0`, `v0.1.2`). With Actions secrets, we can publish to crates.io with token configured before hand without leaking. 

Now the only missing piece is a valid cargo token. This require repo owner @moriturus to setup secret in repo settings [actions secret page](https://github.com/moriturus/ktra/settings/secrets/actions)(only repo owner can open this link).
I named the cargo token `CARGO_TOKEN` and here is a snapshot of another repo that has correctly setup cargo token in action secrests.
<img width="804" alt="image" src="https://user-images.githubusercontent.com/16273287/188250709-91c3fc00-3685-4d5a-b260-ce25c8477f41.png">

Here I call for @moriturus to manually add CARGO_TOKEN to repo setting.

Thanks a lot.