### PR TITLE
Fix compilation with "crates-io-mirroring" turned off

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn apis(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let routes = get::apis(db_manager.clone(), dl_dir_path.clone(), dl_path)
         .or(delete::apis(db_manager.clone(), index_manager.clone()))
-        .or(put::apis(db_manager, index_manager, dl_dir_path));
+        .or(put::apis(db_manager.clone(), index_manager, dl_dir_path));
     #[cfg(not(feature = "openid"))]
     let routes = routes.or(post::apis(db_manager.clone()));
     routes


### PR DESCRIPTION
This looks like it was missed when the openid feature was added.