### PR TITLE
Add deployment dependency: openssh-client

### DIFF
--- a/docker/ktra.Dockerfile
+++ b/docker/ktra.Dockerfile
@@ -25,7 +25,7 @@ LABEL org.opencontainers.image.licenses "(Apache-2.0 OR MIT)"
 
 RUN apt-get update &&\
     apt-get upgrade -y &&\
-    apt-get install -y libssl1.1 ca-certificates &&\
+    apt-get install -y libssl1.1 ca-certificates openssh-client &&\
     apt-get autoremove -y &&\
     apt-get clean -y
 

--- a/docker/ktra_openid.Dockerfile
+++ b/docker/ktra_openid.Dockerfile
@@ -25,7 +25,7 @@ LABEL org.opencontainers.image.licenses "(Apache-2.0 OR MIT)"
 
 RUN apt-get update &&\
     apt-get upgrade -y &&\
-    apt-get install -y libssl1.1 ca-certificates &&\
+    apt-get install -y libssl1.1 ca-certificates openssh-client &&\
     apt-get autoremove -y &&\
     apt-get clean -y
 


### PR DESCRIPTION
This is necessary to utilize an ssh-key with the index repository. If no ssh is found, libgit never offers the SSH credential option¹ and the server fails with:

    no supported credential type

This enables dockerized deployments with an ssh key, such as Github's Deploy keys.

This change add ~10MB to the container's final size (130MB to 139MB).

¹Specifically, the function in `RemoteCallbacks::credentials` is called with a parameter denoting the set permissible authenticators. When no ssh is found the bit for `CredentialType::SSH_KEY` is disabled. Then subsequently ktra does not check for the ssh key parameter, [here](https://github.com/moriturus/ktra/blob/0c5fed2698a2781ad26f994f3f293a56e04935f6/src/index_manager.rs#L179).