### PR TITLE
Updated dependency versions to eliminate high impact vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ktra"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["moriturus <moriturus@alimensir.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -28,14 +28,14 @@ warp = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 tracing-futures = "0.2"
 futures = "0.3"
 semver = { version = "0.11", features = ["serde"] }
 url = { version = "2.2", features = ["serde"] }
 anyhow = "1.0"
 thiserror = "1.0"
-git2 = "0.13"
+git2 = "0.18"
 bytes = "1.0"
 sha2 = "0.9"
 toml = "0.5"
@@ -50,7 +50,7 @@ rust-argon2 = { version = "0.8", optional = true }
 
 sled = { version = "0.34", optional = true }
 redis = { version = "0.19", features = ["tokio-comp"], optional = true }
-mongodb = { version = "1.1", optional = true }
+mongodb = { version = "2.0", optional = true }
 bson = { version = "1.1", features = ["u2i"], optional = true }
 
 openidconnect = { version = "2.1.1", optional = true }


### PR DESCRIPTION
The clap version is unmaintained, but I got rid of all the other cargo audit findings, seven of which were high impact.  The tests all pass.  I reved the patch number.