### PR TITLE
Enabling RUST_LOG parsing by enabling unicode-case feature of regex crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.2"
+regex = { version = "1.9", features = ["unicode-case"] }
 tracing-futures = "0.2"
 futures = "0.3"
 semver = { version = "0.11", features = ["serde"] }


### PR DESCRIPTION
This pull request proved necessary in order to deploy ktra as a systemd service and have the logs show up with journalctl.